### PR TITLE
Add basic error handling in frontend

### DIFF
--- a/app/frontend/src/reducers/password-reducer.js
+++ b/app/frontend/src/reducers/password-reducer.js
@@ -31,19 +31,28 @@ const passwordSlice = createSlice({
   reducers: {},
   extraReducers: {
     [createPasswordThunk.fulfilled]: (state, action) => {
-      alert(action.payload.data.status);
+      const payload = action.payload;
+      const msg =
+        "data" in payload ? payload.data.status : payload.response.data.error;
+      alert(msg);
     },
     [fetchPasswordsThunk.fulfilled]: (state, action) => {
       state.passwords = action.payload.data;
     },
     [rotateAESKeyAndIVThunk.fulfilled]: (state, action) => {
-      alert("AES Key and IV rotated successfully");
-      const updatedPassword = action.payload.data.password;
-      for (let i = 0; i < state.passwords.length; i++) {
-        if (state.passwords[i].pass_uid === updatedPassword.pass_uid) {
-          state.passwords[i].aes_last_rotated =
-            updatedPassword.aes_last_rotated;
+      const payload = action.payload;
+
+      if ("data" in payload) {
+        alert("AES Key and IV rotated successfully");
+        const updatedPassword = payload.data.password;
+        for (let i = 0; i < state.passwords.length; i++) {
+          if (state.passwords[i].pass_uid === updatedPassword.pass_uid) {
+            state.passwords[i].aes_last_rotated =
+              updatedPassword.aes_last_rotated;
+          }
         }
+      } else {
+        alert(payload.response.data.error);
       }
     },
     [rotateCharsetThunk.fulfilled]: (state, action) => {
@@ -57,22 +66,34 @@ const passwordSlice = createSlice({
       }
     },
     [encryptPasswordThunk.fulfilled]: (state, action) => {
-      const encryptedPasswordArr = action.payload.data.encryptedPassword
-        .split("")
-        .map((char) => {
-          return parseInt(char);
-        });
+      const payload = action.payload;
 
-      const aimLength = ROWS * COLS;
-      const paddedArray = Array(aimLength).fill(0);
-      encryptedPasswordArr.forEach(
-        (value, index) => (paddedArray[index] = value)
-      );
+      if ("data" in payload) {
+        const encryptedPasswordArr = action.payload.data.encryptedPassword
+          .split("")
+          .map((char) => {
+            return parseInt(char);
+          });
 
-      state.encryptedData = paddedArray;
+        const aimLength = ROWS * COLS;
+        const paddedArray = Array(aimLength).fill(0);
+        encryptedPasswordArr.forEach(
+          (value, index) => (paddedArray[index] = value)
+        );
+
+        state.encryptedData = paddedArray;
+      } else {
+        alert(payload.response.data.error);
+      }
     },
     [decryptPasswordThunk.fulfilled]: (state, action) => {
-      state.decryptedData = action.payload.data.decrypted;
+      const payload = action.payload;
+
+      if ("data" in payload) {
+        state.decryptedData = action.payload.data.decrypted;
+      } else {
+        alert(payload.response.data.error);
+      }
     },
   },
 });

--- a/app/frontend/src/services/password-thunk.js
+++ b/app/frontend/src/services/password-thunk.js
@@ -5,8 +5,12 @@ import * as passwordService from "./password-service";
 export const createPasswordThunk = createAsyncThunk(
   "password/createPassword",
   async (payload) => {
-    const response = await passwordService.createPassword(payload.identifier);
-    return response;
+    try {
+      const response = await passwordService.createPassword(payload.identifier);
+      return response;
+    } catch (e) {
+      return e;
+    }
   }
 );
 
@@ -21,8 +25,12 @@ export const fetchPasswordsThunk = createAsyncThunk(
 export const rotateAESKeyAndIVThunk = createAsyncThunk(
   "password/rotateAESKeyAndIV",
   async (payload) => {
-    const response = await passwordService.rotateAESKeyAndIV(payload.passUid);
-    return response;
+    try {
+      const response = await passwordService.rotateAESKeyAndIV(payload.passUid);
+      return response;
+    } catch (e) {
+      return e;
+    }
   }
 );
 
@@ -37,21 +45,29 @@ export const rotateCharsetThunk = createAsyncThunk(
 export const encryptPasswordThunk = createAsyncThunk(
   "password/encryptPassword",
   async (payload) => {
-    const response = await passwordService.encryptPassword(
-      payload.passUid,
-      payload.password
-    );
-    return response;
+    try {
+      const response = await passwordService.encryptPassword(
+        payload.passUid,
+        payload.password
+      );
+      return response;
+    } catch (e) {
+      return e;
+    }
   }
 );
 
 export const decryptPasswordThunk = createAsyncThunk(
   "password/decryptPassword",
   async (payload) => {
-    const response = await passwordService.decryptPassword(
-      payload.passUid,
-      payload.pmsFile
-    );
-    return response;
+    try {
+      const response = await passwordService.decryptPassword(
+        payload.passUid,
+        payload.pmsFile
+      );
+      return response;
+    } catch (e) {
+      return e;
+    }
   }
 );

--- a/app/microservices/image-decryptor/app.py
+++ b/app/microservices/image-decryptor/app.py
@@ -7,7 +7,7 @@ import uuid
 from utils.decrypt_utils import decode_memory
 from utils.mongo_connection import MongoDB
 from utils.charset_utils import decode_charset
-from utils.command_utils import decrypt_aes
+from utils.command_utils import decrypt_aes, CommandOutputType
 from utils.constants import PRIMISTORE_DIR
 
 app = FastAPI()
@@ -36,7 +36,6 @@ async def root():
 
 
 @app.post("/password/decrypt/{pass_uid}")
-# async def decrypt_password(pass_uid: str, body: DecryptBody):
 async def decrypt_password(pass_uid: str, file: UploadFile):
     password = db_conn.find_one({"pass_uid": pass_uid})
     if password == None:
@@ -55,9 +54,7 @@ async def decrypt_password(pass_uid: str, file: UploadFile):
         encrypted_string=charset_decrypted,
     )
 
-    if decrypted is None:
-        return JSONResponse(
-            content={"status": "OpenSSL not installed!"}, status_code=500
-        )
+    if decrypted.type_ == CommandOutputType.ERROR:
+        return JSONResponse(content={"error": decrypted.value}, status_code=500)
 
-    return {"decrypted": decrypted}
+    return {"decrypted": decrypted.value}

--- a/app/microservices/image-decryptor/utils/command_utils.py
+++ b/app/microservices/image-decryptor/utils/command_utils.py
@@ -1,18 +1,31 @@
 import subprocess
 from typing import Optional
+from enum import Enum
+from dataclasses import dataclass
 
 
-def run_command(command) -> Optional[str]:
+class CommandOutputType(Enum):
+    ERROR = 1
+    SUCCESS = 2
+
+
+@dataclass
+class CommandOutput:
+    type_: CommandOutputType
+    value: str
+
+
+def run_command(command) -> CommandOutput:
     try:
         result = subprocess.run(
             command, check=True, shell=True, text=True, capture_output=True
         )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError:
-        return None
+        return CommandOutput(CommandOutputType.SUCCESS, result.stdout.strip())
+    except Exception as e:
+        return CommandOutput(CommandOutputType.ERROR, str(e))
 
 
-def decrypt_aes(key, iv, encrypted_string) -> Optional[str]:
+def decrypt_aes(key, iv, encrypted_string) -> CommandOutput:
     decrypted = run_command(
         f"echo '{encrypted_string}' | openssl aes-256-cbc -d -a -K {key} -iv {iv}"
     )

--- a/app/microservices/password-manager/utils/command-utils.js
+++ b/app/microservices/password-manager/utils/command-utils.js
@@ -1,10 +1,23 @@
 import { execSync } from "child_process";
 
+const CommandOutputType = {
+  Success: 0,
+  Error: 1,
+};
+
+class CommandOutput {
+  constructor(type, value) {
+    this.type = type;
+    this.value = value;
+  }
+}
+
 const runCommand = (cmd) => {
   try {
-    return execSync(cmd).toString().trim();
-  } catch {
-    return null;
+    const output = execSync(cmd).toString().trim();
+    return new CommandOutput(CommandOutputType.Success, output);
+  } catch (e) {
+    return new CommandOutput(CommandOutputType.Error, e.message);
   }
 };
 
@@ -26,4 +39,4 @@ const encryptWithAES = (key, iv, password) => {
   return encryptedOutput;
 };
 
-export { runCommand, generateAESKeyIV, encryptWithAES };
+export { runCommand, generateAESKeyIV, encryptWithAES, CommandOutputType };


### PR DESCRIPTION
Closes #1 

**Implementation**

1. Catch errors on axios requests in frontend and throw the error, which then has the actual error message payload inside action -> payload -> response -> data.
2. Send appropriate error messages from both microservice backends when a command is run, return either an error with the message or success with the output, and depending on the type of the returned value (error or success), either send a 200 or a 500 with appropriate output or error message respectively. 