### PR TITLE
Support for CPU temp display in UI

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import DecryptPassword from "./components/pages/DecryptPassword/DecryptPassword"
 import CreatePassword from "./components/pages/CreatePassword/CreatePassword";
 import GeneratePassword from "./components/pages/GeneratePassword/GeneratePassword";
 import { VERSION } from "./utils/version";
+import DeviceInfo from "./components/pages/DeviceInfo/DeviceInfo";
 
 const store = configureStore({
   reducer: {
@@ -43,6 +44,7 @@ const App = () => {
             element={<DecryptPassword />}
           />
           <Route path="/generate-password" element={<GeneratePassword />} />
+          <Route path="/device-info" element={<DeviceInfo />} />
         </Routes>
       </Provider>
     </div>

--- a/frontend/src/components/pages/DeviceInfo/DeviceInfo.js
+++ b/frontend/src/components/pages/DeviceInfo/DeviceInfo.js
@@ -1,10 +1,14 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import NavBar from "../../parts/NavBar/NavBar";
 import ToggleButton from "../../parts/ToggleButton/ToggleButton";
+import { useDispatch, useSelector } from "react-redux";
+import { getCpuTempThunk } from "../../../services/password-thunk";
 
 const DeviceInfo = () => {
-  const cpuTemp = 30.6;
+  const { cpuTemp } = useSelector((state) => state.password);
   const [currentScale, setCurrentScale] = useState("C");
+
+  const dispatch = useDispatch();
 
   const convertCToF = (tempVal) => {
     return ((9 * tempVal) / 5 + 32).toFixed(1);
@@ -12,15 +16,21 @@ const DeviceInfo = () => {
 
   const formatTemp = (tempVal) => {
     let convertedTempVal = tempVal;
-    if (currentScale === "F") {
+    if (tempVal !== null && currentScale === "F") {
       convertedTempVal = convertCToF(tempVal);
     }
-    return tempVal !== null ? `${convertedTempVal}°${currentScale}` : "";
+    return tempVal !== null
+      ? `${convertedTempVal}°${currentScale}`
+      : "Cannot determine CPU temperature";
   };
 
   const handleScaleToggle = (isChecked) => {
     setCurrentScale(isChecked ? "F" : "C");
   };
+
+  useEffect(() => {
+    dispatch(getCpuTempThunk());
+  });
 
   return (
     <div>

--- a/frontend/src/components/pages/DeviceInfo/DeviceInfo.js
+++ b/frontend/src/components/pages/DeviceInfo/DeviceInfo.js
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import NavBar from "../../parts/NavBar/NavBar";
+import ToggleButton from "../../parts/ToggleButton/ToggleButton";
+
+const DeviceInfo = () => {
+  const cpuTemp = 30.6;
+  const [currentScale, setCurrentScale] = useState("C");
+
+  const convertCToF = (tempVal) => {
+    return ((9 * tempVal) / 5 + 32).toFixed(1);
+  };
+
+  const formatTemp = (tempVal) => {
+    let convertedTempVal = tempVal;
+    if (currentScale === "F") {
+      convertedTempVal = convertCToF(tempVal);
+    }
+    return tempVal !== null ? `${convertedTempVal}°${currentScale}` : "";
+  };
+
+  const handleScaleToggle = (isChecked) => {
+    setCurrentScale(isChecked ? "F" : "C");
+  };
+
+  return (
+    <div>
+      <NavBar />
+
+      <p className="text-right">
+        <ToggleButton
+          leftOption={"°C"}
+          rightOption={"°F"}
+          parentUpdateCallback={handleScaleToggle}
+        />
+      </p>
+
+      <div className="text-center">
+        <p>
+          <strong>CPU Temperature: </strong>
+          {formatTemp(cpuTemp)}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default DeviceInfo;

--- a/frontend/src/components/parts/NavBar/NavBar.js
+++ b/frontend/src/components/parts/NavBar/NavBar.js
@@ -12,7 +12,7 @@ const NavBar = () => {
         >
           PrimiStore v{VERSION}
         </NavLink>
-        <div className="lg:w-9/12 xl:w-7/12 2xl:w-6/12">
+        <div className="lg:w-9/12 xl:w-8/12 2xl:w-6/12">
           <ul className="font-medium rounded-lg flex flex-row justify-between items-center lg:space-x-1">
             <li>
               <NavLink
@@ -52,6 +52,16 @@ const NavBar = () => {
                 to={{ pathname: "/generate-password" }}
               >
                 Generate Safe Password
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
+                className={({ isActive }) =>
+                  isActive ? "activeNavLink" : "defaultNavLink"
+                }
+                to={{ pathname: "/device-info" }}
+              >
+                Device Info
               </NavLink>
             </li>
           </ul>

--- a/frontend/src/components/parts/ToggleButton/ToggleButton.js
+++ b/frontend/src/components/parts/ToggleButton/ToggleButton.js
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+
+const ToggleButton = ({ leftOption, rightOption, parentUpdateCallback }) => {
+  const [isChecked, setIsChecked] = useState(false);
+
+  const handleCheckboxChange = () => {
+    setIsChecked(!isChecked);
+    parentUpdateCallback(!isChecked);
+  };
+
+  return (
+    <>
+      <label className="themeSwitcherTwo relative inline-flex cursor-pointer select-none items-center me-5">
+        <input
+          type="checkbox"
+          checked={isChecked}
+          onChange={handleCheckboxChange}
+          className="sr-only"
+        />
+        <span className="label flex items-center text-sm font-medium text-black">
+          {leftOption}
+        </span>
+        <span
+          className={`slider mx-1 flex h-8 w-[60px] items-center rounded-full p-1 duration-200 ${
+            isChecked ? "bg-[#212b36]" : "bg-[#CCCCCE]"
+          }`}
+        >
+          <span
+            className={`dot h-6 w-6 rounded-full bg-white duration-200 ${
+              isChecked ? "translate-x-[28px]" : ""
+            }`}
+          ></span>
+        </span>
+        <span className="label flex items-center text-sm font-medium text-black">
+          {rightOption}
+        </span>
+      </label>
+    </>
+  );
+};
+
+export default ToggleButton;

--- a/frontend/src/reducers/password-reducer.js
+++ b/frontend/src/reducers/password-reducer.js
@@ -5,6 +5,7 @@ import {
   deletePasswordThunk,
   encryptPasswordThunk,
   fetchPasswordsThunk,
+  getCpuTempThunk,
   rotateAESKeyAndIVThunk,
   rotateCharsetThunk,
 } from "../services/password-thunk";
@@ -25,6 +26,7 @@ const initialState = {
   encryptedData: getZeros2DArray(ROWS, COLS),
   decryptedData: "",
   rawData: "",
+  cpuTemp: null,
 };
 
 const passwordSlice = createSlice({
@@ -113,6 +115,15 @@ const passwordSlice = createSlice({
         state.passwords = newPasswords;
       } else {
         alert(payload.response.data.error);
+      }
+    },
+    [getCpuTempThunk.fulfilled]: (state, action) => {
+      const payload = action.payload;
+
+      if ("data" in payload) {
+        state.cpuTemp = payload.data.temp;
+      } else {
+        state.cpuTemp = null;
       }
     },
   },

--- a/frontend/src/services/password-service.js
+++ b/frontend/src/services/password-service.js
@@ -65,3 +65,10 @@ export const deletePassword = async (passUid) => {
   );
   return response;
 };
+
+export const getCpuTemp = async () => {
+  const response = await axios.get(
+    `${PASSWORD_MANAGER_API_BASE}/device/cpu-temp`
+  );
+  return response;
+};

--- a/frontend/src/services/password-thunk.js
+++ b/frontend/src/services/password-thunk.js
@@ -83,3 +83,15 @@ export const deletePasswordThunk = createAsyncThunk(
     }
   }
 );
+
+export const getCpuTempThunk = createAsyncThunk(
+  "password/getCpuTemp",
+  async () => {
+    try {
+      const response = await passwordService.getCpuTemp();
+      return response;
+    } catch (e) {
+      return e;
+    }
+  }
+);

--- a/microservices/password-manager/controllers/primistore/primistore-controller.js
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.js
@@ -186,7 +186,7 @@ const cpuTempFetchHandler = (req, res, logger) => {
     logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 200`);
     res.status(200).send({
       status: cpuTempOutput.typeValueStr,
-      temp: cpuTempOutput.value,
+      temp: parseFloat(cpuTempOutput.value.split("=")[1].split("'")[0]),
     });
   } else {
     logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 500`);

--- a/microservices/password-manager/controllers/primistore/primistore-controller.js
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.js
@@ -185,7 +185,6 @@ const cpuTempFetchHandler = (req, res, logger) => {
   if (cpuTempOutput.type == CommandOutputType.Success) {
     logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 200`);
     res.status(200).send({
-      status: cpuTempOutput.typeValueStr,
       temp: parseFloat(cpuTempOutput.value.split("=")[1].split("'")[0]).toFixed(
         1
       ),
@@ -193,7 +192,6 @@ const cpuTempFetchHandler = (req, res, logger) => {
   } else {
     logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 500`);
     res.status(500).send({
-      status: cpuTempOutput.typeValueStr,
       error: cpuTempOutput.value,
     });
   }

--- a/microservices/password-manager/controllers/primistore/primistore-controller.js
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.js
@@ -20,6 +20,7 @@ import {
 } from "../../utils/charset-utils.js";
 import { PRIMISTORE_DIR } from "../../utils/path-utils.js";
 import { getCurrentTime } from "../../utils/date-utils.js";
+import { getCpuTemp } from "../../utils/device-utils.js";
 
 const passwordCreationHandler = async (req, res, logger) => {
   const password_uid = req.body.identifier;
@@ -178,6 +179,24 @@ const deletePasswordHandler = async (req, res, logger) => {
   });
 };
 
+const cpuTempFetchHandler = (req, res, logger) => {
+  const cpuTempOutput = getCpuTemp();
+
+  if (cpuTempOutput.type == CommandOutputType.Success) {
+    logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 200`);
+    res.status(200).send({
+      status: cpuTempOutput.typeValueStr,
+      temp: cpuTempOutput.value,
+    });
+  } else {
+    logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 500`);
+    res.status(500).send({
+      status: cpuTempOutput.typeValueStr,
+      error: cpuTempOutput.value,
+    });
+  }
+};
+
 const PrimistoreController = (app, logger) => {
   app.post("/password", (req, res) =>
     passwordCreationHandler(req, res, logger)
@@ -194,6 +213,10 @@ const PrimistoreController = (app, logger) => {
   );
   app.delete("/password/:pass_uid", (req, res) =>
     deletePasswordHandler(req, res, logger)
+  );
+
+  app.get("/device/cpu-temp", (req, res) =>
+    cpuTempFetchHandler(req, res, logger)
   );
 };
 

--- a/microservices/password-manager/controllers/primistore/primistore-controller.js
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.js
@@ -186,7 +186,9 @@ const cpuTempFetchHandler = (req, res, logger) => {
     logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 200`);
     res.status(200).send({
       status: cpuTempOutput.typeValueStr,
-      temp: parseFloat(cpuTempOutput.value.split("=")[1].split("'")[0]),
+      temp: parseFloat(cpuTempOutput.value.split("=")[1].split("'")[0]).toFixed(
+        1
+      ),
     });
   } else {
     logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 500`);

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -9,7 +9,6 @@ class CommandOutput {
   constructor(type, value) {
     this.type = type;
     this.value = value;
-    this.typeValueStr = type === 0 ? "SUCCESS" : "ERROR";
   }
 }
 

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -9,6 +9,7 @@ class CommandOutput {
   constructor(type, value) {
     this.type = type;
     this.value = value;
+    this.typeValueStr = type === 0 ? "SUCCESS" : "ERROR";
   }
 }
 

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -1,0 +1,7 @@
+import { runCommand } from "./command-utils.js";
+
+const getCpuTemp = () => {
+  return runCommand("vcgencmd measure_temp");
+};
+
+export { getCpuTemp };


### PR DESCRIPTION
Closes #27 

**Implementation**

1. Added an endpoint to access the CPU temperature, this uses existing command running capabilities in the `password-manager` microservice to run `vcgencmd` to get the temperature. 
2. Add a new page to display device information, add this to the navbar and adjust navbar size accordingly. 
3. Add a new part component for creating toggle button to toggle between celsius and fahrenheit scale while displaying CPU temperature.  
4. Use axios to and redux to make an API call and fetch CPU temperature from the API and accordingly update the temperature in device info. 