### PR TITLE
Add backup script for pi

### DIFF
--- a/pi/backup.sh
+++ b/pi/backup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+MONGO_CONTAINER_COUNTS=$(sudo docker ps -q --filter "ancestor=mongo:bionic" | wc -l)
+if [ "$MONGO_CONTAINER_COUNTS" -eq "1" ]; then
+    CURRENT_TIME=$(date +%s)
+    BACKUP_DIR=primistore-$CURRENT_TIME
+    BACKUP_TARBALL_PATH=$BACKUP_DIR.tar.gz
+    PRIMISTORE_DIR=.primistore
+    PRIMISTORE_TARBALL_PATH=primistore-backup-$CURRENT_TIME.tar.gz
+
+    cd ~/
+    MONGO_CONTAINER_ID=$(sudo docker ps -q --filter "ancestor=mongo:bionic" | head -n 1)
+    sudo docker exec -it $MONGO_CONTAINER_ID mongodump --host localhost --db primistore
+    sudo docker cp $MONGO_CONTAINER_ID:/dump .
+    sudo tar czf mongodump.tar.gz dump
+    sudo rm -rf dump
+    sudo docker exec -it $MONGO_CONTAINER_ID rm -rf /dump
+    sudo mkdir $BACKUP_DIR
+    sudo mv mongodump.tar.gz $BACKUP_DIR
+    sudo tar czf $PRIMISTORE_TARBALL_PATH $PRIMISTORE_DIR
+    sudo mv $PRIMISTORE_TARBALL_PATH $BACKUP_DIR
+    sudo tar czf $BACKUP_TARBALL_PATH $BACKUP_DIR
+    sudo rm -rf $BACKUP_DIR
+else
+    echo "More than one containers running MongoDB, please check your docker setup"
+fi


### PR DESCRIPTION
Closes #28 

**Implementation**

1. Add a script that does the following:
    a. Get all the containers running `mongo:bionic` (as that is the version of mongo used in docker containers).
    b. If there is a single container running it, then it surely is the one used by the apps.
    c. Using the container id, execute `mongodump` command to generate a dump, pull it out, tar it, and delete the dump directory from host and docker container running mongo.
    d. Generate a tarball from the `.primistore` directly (which for now just holds the charset text files). 
    e. Put it all in a directory and tar it, and the backup is ready. 