### PR TITLE
Add checks for program existence in provisioning script

### DIFF
--- a/pi/primistore-startup.sh
+++ b/pi/primistore-startup.sh
@@ -2,6 +2,31 @@
 
 # A bash script to be run on Raspberry Pi startup to spin
 # up the apps
+
+check_command_installed() {
+	if [ -z "$1" ]; then
+		echo "Please install $2, use 'sudo apt install $2 -y'"
+        return 1
+	fi
+
+    return 0
+}
+
+IFCONFIG_OUTPUT=$(which ifconfig)
+TOTAL=0
+check_command_installed "$IFCONFIG_OUTPUT" "net-tools"
+TOTAL=$((TOTAL + $?))
+DOCKER_OUTPUT=$(which docker)
+check_command_installed "$DOCKER_OUTPUT" "docker.io"
+TOTAL=$((TOTAL + $?))
+DOCKER_COMPOSE_OUTPUT=$(which docker-compose)
+check_command_installed "$DOCKER_COMPOSE_OUTPUT" "docker-compose"
+TOTAL=$((TOTAL + $?))
+if [ $TOTAL -gt 0 ]; then
+	echo "Some errors exist"
+	return 1
+fi
+
 IP=`python3 /usr/bin/get_current_ip.py`
 LOCAL_DIR=$HOME/.primistore
 DOCKER_COMPOSE_PATH=$HOME/docker-compose-prod-pi.yml

--- a/pi/primistore-startup.sh
+++ b/pi/primistore-startup.sh
@@ -4,7 +4,8 @@
 # up the apps
 
 check_command_installed() {
-	if [ -z "$1" ]; then
+    OUTPUT=$(which $1)
+	if [ -z "$OUTPUT" ]; then
 		echo "Please install $2, use 'sudo apt install $2 -y'"
         return 1
 	fi
@@ -12,15 +13,12 @@ check_command_installed() {
     return 0
 }
 
-IFCONFIG_OUTPUT=$(which ifconfig)
 TOTAL=0
-check_command_installed "$IFCONFIG_OUTPUT" "net-tools"
+check_command_installed "ifconfig" "net-tools"
 TOTAL=$((TOTAL + $?))
-DOCKER_OUTPUT=$(which docker)
-check_command_installed "$DOCKER_OUTPUT" "docker.io"
+check_command_installed "docker" "docker.io"
 TOTAL=$((TOTAL + $?))
-DOCKER_COMPOSE_OUTPUT=$(which docker-compose)
-check_command_installed "$DOCKER_COMPOSE_OUTPUT" "docker-compose"
+check_command_installed "docker-compose" "docker-compose"
 TOTAL=$((TOTAL + $?))
 if [ $TOTAL -gt 0 ]; then
 	echo "Some errors exist"


### PR DESCRIPTION
Closes #22 
Closes #23 

**Implementation**

1. Add a function in the provisioning script that checks the value of `which <program>` and if it returns an empty string then return 1 or 0.
2. Get a total of all the return values, if it is non zero then it means some command was missing and stop further execution.