### PR TITLE
Add device info for Pi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - DB_CONNECTION_STRING=mongodb://mongodb:27017/primistore
     volumes:
       - ${LOCAL_DIR}:/root/.primistore
+      - ${PIPE_PATH}:/command-runner
+      - ${PIPE_OUTPUT_FILE}:/output.txt
 
   image_decryptor:
     build:
@@ -33,8 +35,6 @@ services:
       - DB_CONNECTION_STRING=mongodb://mongodb:27017/primistore
     volumes:
       - ${LOCAL_DIR}:/root/.primistore
-      - ${PIPE_PATH}:/command-runner
-      - ${PIPE_OUTPUT_FILE}:/output.txt
 
   mongodb:
     image: mongo:bionic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - DB_CONNECTION_STRING=mongodb://mongodb:27017/primistore
     volumes:
       - ${LOCAL_DIR}:/root/.primistore
+      - ${PIPE_PATH}:/command-runner
+      - ${PIPE_OUTPUT_FILE}:/output.txt
 
   mongodb:
     image: mongo:bionic

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.2",
+  "version": "0.3",
   "private": true,
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.7",

--- a/frontend/src/components/pages/DeviceInfo/DeviceInfo.js
+++ b/frontend/src/components/pages/DeviceInfo/DeviceInfo.js
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from "react";
 import NavBar from "../../parts/NavBar/NavBar";
 import ToggleButton from "../../parts/ToggleButton/ToggleButton";
 import { useDispatch, useSelector } from "react-redux";
-import { getCpuTempThunk } from "../../../services/password-thunk";
+import { getDeviceInfoThunk } from "../../../services/password-thunk";
 
 const DeviceInfo = () => {
-  const { cpuTemp } = useSelector((state) => state.password);
+  const { deviceInfo } = useSelector((state) => state.password);
   const [currentScale, setCurrentScale] = useState("C");
 
   const dispatch = useDispatch();
@@ -16,12 +16,12 @@ const DeviceInfo = () => {
 
   const formatTemp = (tempVal) => {
     let convertedTempVal = tempVal;
-    if (tempVal !== null && currentScale === "F") {
+    if (tempVal !== "Cannot determine" && currentScale === "F") {
       convertedTempVal = convertCToF(tempVal);
     }
-    return tempVal !== null
+    return tempVal !== "Cannot determine"
       ? `${convertedTempVal}°${currentScale}`
-      : "Cannot determine CPU temperature";
+      : tempVal;
   };
 
   const handleScaleToggle = (isChecked) => {
@@ -29,8 +29,8 @@ const DeviceInfo = () => {
   };
 
   useEffect(() => {
-    dispatch(getCpuTempThunk());
-  });
+    dispatch(getDeviceInfoThunk());
+  }, [dispatch]);
 
   return (
     <div>
@@ -44,11 +44,13 @@ const DeviceInfo = () => {
         />
       </p>
 
-      <div className="text-center">
-        <p>
-          <strong>CPU Temperature: </strong>
-          {formatTemp(cpuTemp)}
-        </p>
+      <div className="text-center" style={{ marginLeft: "10px" }}>
+        {Object.entries(deviceInfo).map(([key, value]) => (
+          <li style={{ textAlign: "left" }}>
+            <strong>{key}: </strong>
+            {key.includes("Temperature") ? formatTemp(value) : value}
+          </li>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/reducers/password-reducer.js
+++ b/frontend/src/reducers/password-reducer.js
@@ -5,7 +5,7 @@ import {
   deletePasswordThunk,
   encryptPasswordThunk,
   fetchPasswordsThunk,
-  getCpuTempThunk,
+  getDeviceInfoThunk,
   rotateAESKeyAndIVThunk,
   rotateCharsetThunk,
 } from "../services/password-thunk";
@@ -26,7 +26,7 @@ const initialState = {
   encryptedData: getZeros2DArray(ROWS, COLS),
   decryptedData: "",
   rawData: "",
-  cpuTemp: null,
+  deviceInfo: {},
 };
 
 const passwordSlice = createSlice({
@@ -117,13 +117,13 @@ const passwordSlice = createSlice({
         alert(payload.response.data.error);
       }
     },
-    [getCpuTempThunk.fulfilled]: (state, action) => {
+    [getDeviceInfoThunk.fulfilled]: (state, action) => {
       const payload = action.payload;
 
       if ("data" in payload) {
-        state.cpuTemp = payload.data.temp;
+        state.deviceInfo = payload.data.info;
       } else {
-        state.cpuTemp = null;
+        state.deviceInfo = {};
       }
     },
   },

--- a/frontend/src/services/password-service.js
+++ b/frontend/src/services/password-service.js
@@ -66,9 +66,9 @@ export const deletePassword = async (passUid) => {
   return response;
 };
 
-export const getCpuTemp = async () => {
+export const getDeviceInfo = async () => {
   const response = await axios.get(
-    `${PASSWORD_MANAGER_API_BASE}/device/cpu-temp`
+    `${PASSWORD_MANAGER_API_BASE}/device/device-info`
   );
   return response;
 };

--- a/frontend/src/services/password-thunk.js
+++ b/frontend/src/services/password-thunk.js
@@ -84,11 +84,11 @@ export const deletePasswordThunk = createAsyncThunk(
   }
 );
 
-export const getCpuTempThunk = createAsyncThunk(
-  "password/getCpuTemp",
+export const getDeviceInfoThunk = createAsyncThunk(
+  "password/getDeviceInfo",
   async () => {
     try {
-      const response = await passwordService.getCpuTemp();
+      const response = await passwordService.getDeviceInfo();
       return response;
     } catch (e) {
       return e;

--- a/microservices/password-manager/controllers/primistore/primistore-controller.js
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.js
@@ -20,7 +20,7 @@ import {
 } from "../../utils/charset-utils.js";
 import { PRIMISTORE_DIR } from "../../utils/path-utils.js";
 import { getCurrentTime } from "../../utils/date-utils.js";
-import { getCpuTemp } from "../../utils/device-utils.js";
+import { getDeviceInfo } from "../../utils/device-utils.js";
 
 const passwordCreationHandler = async (req, res, logger) => {
   const password_uid = req.body.identifier;
@@ -179,22 +179,13 @@ const deletePasswordHandler = async (req, res, logger) => {
   });
 };
 
-const cpuTempFetchHandler = (req, res, logger) => {
-  const cpuTempOutput = getCpuTemp();
+const deviceInfoFetchHandler = (req, res, logger) => {
+  const deviceInfo = getDeviceInfo();
 
-  if (cpuTempOutput.type == CommandOutputType.Success) {
-    logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 200`);
-    res.status(200).send({
-      temp: parseFloat(cpuTempOutput.value.split("=")[1].split("'")[0]).toFixed(
-        1
-      ),
-    });
-  } else {
-    logger.info(`[${getCurrentTime()}] GET /device/cpu-temp : Status 500`);
-    res.status(500).send({
-      error: cpuTempOutput.value,
-    });
-  }
+  logger.info(`[${getCurrentTime()}] GET /device/device-info : Status 200`);
+  res.status(200).send({
+    info: deviceInfo,
+  });
 };
 
 const PrimistoreController = (app, logger) => {
@@ -215,8 +206,8 @@ const PrimistoreController = (app, logger) => {
     deletePasswordHandler(req, res, logger)
   );
 
-  app.get("/device/cpu-temp", (req, res) =>
-    cpuTempFetchHandler(req, res, logger)
+  app.get("/device/device-info", (req, res) =>
+    deviceInfoFetchHandler(req, res, logger)
   );
 };
 

--- a/microservices/password-manager/controllers/primistore/primistore-controller.js
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.js
@@ -179,7 +179,7 @@ const deletePasswordHandler = async (req, res, logger) => {
   });
 };
 
-const deviceInfoFetchHandler = (req, res, logger) => {
+const deviceInfoFetchHandler = async (req, res, logger) => {
   const deviceInfo = getDeviceInfo();
 
   logger.info(`[${getCurrentTime()}] GET /device/device-info : Status 200`);

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -1,11 +1,5 @@
 import { execSync } from "child_process";
-import {
-  createWriteStream,
-  existsSync,
-  readFileSync,
-  stat,
-  unlinkSync,
-} from "fs";
+import { createWriteStream, existsSync, readFileSync, statSync } from "fs";
 
 const PIPE_PATH = "/command-runner";
 const PIPE_OUTPUT_PATH = "/output.txt";
@@ -39,16 +33,8 @@ const sleep = (ms) => {
 };
 
 const getFileLastModified = (filePath) => {
-  let lastModified;
-  stat(filePath, (err, stats) => {
-    if (err) {
-      lastModified = -2;
-    } else {
-      lastModified = Math.round(stats.mtimeMs);
-    }
-  });
-
-  return lastModified;
+  let stats = statSync(filePath);
+  return stats.mtimeMs;
 };
 
 const runCommandInPipe = (cmd) => {

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -3,7 +3,6 @@ import { createWriteStream, existsSync, readFileSync, unlinkSync } from "fs";
 
 const PIPE_PATH = "/command-runner";
 const PIPE_OUTPUT_PATH = "/output.txt";
-const PIPED_CMD_TIMEOUT = 3000; // 3 seconds
 
 const CommandOutputType = {
   Success: 0,
@@ -26,10 +25,10 @@ const runCommand = (cmd) => {
   }
 };
 
-function sleep(ms) {
+const sleep = (ms) => {
   const start = Date.now();
   while (Date.now() - start < ms) {}
-}
+};
 
 const runCommandInPipe = (cmd) => {
   if (!existsSync(PIPE_PATH)) {

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -26,37 +26,23 @@ const runCommand = (cmd) => {
   }
 };
 
-const runCommandInPipe = (cmd) => {
-  if (existsSync(PIPE_OUTPUT_PATH)) {
-    unlinkSync(PIPE_OUTPUT_PATH);
-  }
+function sleep(ms) {
+  const start = Date.now();
+  while (Date.now() - start < ms) {}
+}
 
+const runCommandInPipe = (cmd) => {
   const stream = createWriteStream(PIPE_PATH);
   stream.write(cmd);
   stream.close();
 
-  const timeoutStart = Date.now();
   let output = null;
-  const runLoop = setInterval(() => {
-    if (Date.now() - timeoutStart > PIPED_CMD_TIMEOUT) {
-      clearInterval(runLoop);
-      output = new CommandOutput(CommandOutputType.Error, "Timed out");
-    } else {
-      if (existsSync(PIPE_OUTPUT_PATH)) {
-        clearInterval(runLoop);
-        const outputData = readFileSync(PIPE_OUTPUT_PATH).toString();
-        if (existsSync(PIPE_OUTPUT_PATH)) {
-          unlinkSync(PIPE_OUTPUT_PATH);
-        }
-        output = new CommandOutput(CommandOutputType.Success, outputData);
-      } else {
-        output = new CommandOutput(
-          CommandOutputType.Error,
-          "Failed to find run output"
-        );
-      }
-    }
-  }, PIPED_CMD_TIMEOUT);
+
+  sleep(1000);
+  if (existsSync(PIPE_OUTPUT_PATH)) {
+    const outputData = readFileSync(PIPE_OUTPUT_PATH).toString();
+    output = new CommandOutput(CommandOutputType.Success, outputData);
+  }
 
   return output;
 };

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -36,7 +36,10 @@ const runCommandInPipe = (cmd) => {
   stream.write(cmd);
   stream.close();
 
-  let output = null;
+  let output = new CommandOutput(
+    CommandOutputType.Error,
+    "Cannot run command inside pipe"
+  );
 
   sleep(1000);
   if (existsSync(PIPE_OUTPUT_PATH)) {

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -32,6 +32,13 @@ function sleep(ms) {
 }
 
 const runCommandInPipe = (cmd) => {
+  if (!existsSync(PIPE_PATH)) {
+    return new CommandOutput(
+      CommandOutputType.Error,
+      "Cannot run command inside pipe"
+    );
+  }
+
   const stream = createWriteStream(PIPE_PATH);
   stream.write(cmd);
   stream.close();

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -1,8 +1,16 @@
 import { execSync } from "child_process";
-import { createWriteStream, existsSync, readFileSync, unlinkSync } from "fs";
+import {
+  createWriteStream,
+  existsSync,
+  readFileSync,
+  stat,
+  unlinkSync,
+} from "fs";
 
 const PIPE_PATH = "/command-runner";
 const PIPE_OUTPUT_PATH = "/output.txt";
+const PIPE_OUTPUT_CACHE_MINUTES = 3;
+const PIPE_WAIT_SLEEP_TIME = 100; // milliseconds
 
 const CommandOutputType = {
   Success: 0,
@@ -30,12 +38,47 @@ const sleep = (ms) => {
   while (Date.now() - start < ms) {}
 };
 
+const getFileLastModified = (filePath) => {
+  let lastModified;
+  stat(filePath, (err, stats) => {
+    if (err) {
+      lastModified = -2;
+    } else {
+      lastModified = Math.round(stats.mtimeMs);
+    }
+  });
+
+  return lastModified;
+};
+
 const runCommandInPipe = (cmd) => {
   if (!existsSync(PIPE_PATH)) {
     return new CommandOutput(
       CommandOutputType.Error,
       "Cannot run command inside pipe"
     );
+  }
+
+  let lastModified = -1;
+  if (existsSync(PIPE_OUTPUT_PATH)) {
+    const lastModified = getFileLastModified(PIPE_OUTPUT_PATH);
+    if (lastModified == -2) {
+      return CommandOutput(
+        CommandOutputType.Error,
+        "Cannot read command output"
+      );
+    }
+    const now = Date.now();
+    const diff = (now - lastModified) / (1000 * 60);
+
+    // If the last updated time was within threshold
+    // Return the last result, no need to run the program again
+    if (diff <= PIPE_OUTPUT_CACHE_MINUTES) {
+      return new CommandOutput(
+        CommandOutput.Success,
+        readFileSync(PIPE_OUTPUT_PATH).toString()
+      );
+    }
   }
 
   const stream = createWriteStream(PIPE_PATH);
@@ -47,13 +90,35 @@ const runCommandInPipe = (cmd) => {
     "Cannot run command inside pipe"
   );
 
-  sleep(1000);
-  if (existsSync(PIPE_OUTPUT_PATH)) {
-    const outputData = readFileSync(PIPE_OUTPUT_PATH).toString();
-    output = new CommandOutput(CommandOutputType.Success, outputData);
+  // If output path does not exist, wait for it to be created
+  // Edge case, will happen only first time
+  if (lastModified === -1) {
+    while (!existsSync(PIPE_OUTPUT_PATH)) {
+      sleep(PIPE_WAIT_SLEEP_TIME);
+    }
+  } else {
+    // Otherwise wait for the file to be modified
+    while (true) {
+      const lastModifiedMins = Math.round(
+        getFileLastModified(PIPE_OUTPUT_PATH) / (1000 * 60)
+      );
+      if (lastModifiedMins == -2) {
+        return CommandOutput(
+          CommandOutputType.Error,
+          "Cannot read command output"
+        );
+      }
+      const nowMins = Math.round(Date.now() / (1000 * 60));
+
+      if (nowMins - lastModified === 0) {
+        break;
+      }
+      sleep(PIPE_WAIT_SLEEP_TIME);
+    }
   }
 
-  return output;
+  const outputData = readFileSync(PIPE_OUTPUT_PATH).toString();
+  return new CommandOutput(CommandOutputType.Success, outputData);
 };
 
 const generateAESKeyIV = () => {

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -1,4 +1,4 @@
-import { CommandOutputType, runCommand } from "./command-utils.js";
+import { CommandOutputType, runCommandInPipe } from "./command-utils.js";
 
 const convertStringToObject = (rawOutput, keyTransformer) => {
   const systemInfo = {};
@@ -22,7 +22,7 @@ const convertStringToObject = (rawOutput, keyTransformer) => {
 };
 
 const getDeviceInfo = () => {
-  const output = runCommand("/usr/bin/landscape-sysinfo");
+  const output = runCommandInPipe("/usr/bin/landscape-sysinfo");
 
   const keyTransformer = {
     "System load": "System load",

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -1,7 +1,48 @@
-import { runCommand } from "./command-utils.js";
+import { CommandOutputType, runCommand } from "./command-utils.js";
 
-const getCpuTemp = () => {
-  return runCommand("vcgencmd measure_temp");
+const convertStringToObject = (rawOutput, keyTransformer) => {
+  const systemInfo = {};
+  const lines = rawOutput.split("\n");
+
+  for (const line of lines) {
+    const [key, val] = line.split(":", 2);
+    const trimmedKey = key.trim();
+
+    if (!(trimmedKey in keyTransformer)) {
+      continue;
+    }
+
+    const transformedKey = keyTransformer[trimmedKey];
+    const trimmedVal = val.trim();
+
+    systemInfo[transformedKey] = trimmedVal;
+  }
+
+  return systemInfo;
 };
 
-export { getCpuTemp };
+const getDeviceInfo = () => {
+  const output = runCommand("/usr/bin/landscape-sysinfo");
+
+  const keyTransformer = {
+    "System load": "System load",
+    "Usage of /": "Storage",
+    "Memory usage": "RAM usage",
+    "Swap usage": "Swap usage",
+    Temperature: "CPU Temperature",
+    Processes: "Active Processes",
+  };
+
+  let systemInfo = {};
+  if (output.type == CommandOutputType.Success) {
+    systemInfo = convertStringToObject(output.value, keyTransformer);
+  } else {
+    Object.values(keyTransformer).forEach((value) => {
+      systemInfo[value] = "Cannot determine";
+    });
+  }
+
+  return systemInfo;
+};
+
+export { getDeviceInfo };

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -22,7 +22,7 @@ const convertStringToObject = (rawOutput, keyTransformer) => {
 };
 
 const getDeviceInfo = () => {
-  const output = runCommandInPipe("/usr/local/bin/landscape-sysinfo");
+  const output = runCommandInPipe("/usr/bin/landscape-sysinfo");
 
   const keyTransformer = {
     "System load": "System load",

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -36,6 +36,7 @@ const getDeviceInfo = () => {
   let systemInfo = {};
   if (output.type == CommandOutputType.Success) {
     systemInfo = convertStringToObject(output.value, keyTransformer);
+    systemInfo["CPU Temperature"] = systemInfo["CPU Temperature"].split(" ")[0];
   } else {
     Object.values(keyTransformer).forEach((value) => {
       systemInfo[value] = "Cannot determine";

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -22,7 +22,7 @@ const convertStringToObject = (rawOutput, keyTransformer) => {
 };
 
 const getDeviceInfo = () => {
-  const output = runCommandInPipe("/usr/bin/landscape-sysinfo");
+  const output = runCommandInPipe("/usr/local/bin/landscape-sysinfo");
 
   const keyTransformer = {
     "System load": "System load",

--- a/pi/README.md
+++ b/pi/README.md
@@ -4,10 +4,12 @@ This directory contains all the things that are required to run PrimiStore on Ra
 
 ## Description
 
-1. `docker-compose-prod-pi.yml`: This contains completely built images for all microservices, so that it can just be downloaded and run as is to spin up the entire app.
+1. `docker-compose-prod-pi.yml`: This contains completely built images for all microservices, so that it can just be downloaded and run as is to spin up the entire app. This should be moved to the home directory.
 
 2. `get_current_ip.py`: This fetches the IP address of the device, this is used in automation script to spin up containers on Pi startup. This needs to be moved to `/usr/bin` as the startup script expects so.
 
-3. `primistore-startup.sh`: This is a script that can be run on Pi startup to spin up docker containers for all the microservices of the app.
+3. `primistore-startup.sh`: This is a script that can be run on Pi startup to spin up docker containers for all the microservices of the app. This should be moved to the home directory.
 
 4. `nptforce`: This has to be copied to `/usr/bin` and given execute permission (`chmod +x`), then running this command from anywhere in the Pi will force an NTP sync and fix the time.
+
+5. `execute_pipe.py`: Reads data from pipe and executes them as commands, dumps the output to an output file. This should be moved to the home directory.

--- a/pi/docker-compose-prod-pi.yml
+++ b/pi/docker-compose-prod-pi.yml
@@ -19,6 +19,8 @@ services:
       - DB_CONNECTION_STRING=mongodb://mongodb:27017/primistore
     volumes:
       - ${LOCAL_DIR}:/root/.primistore
+      - ${PIPE_PATH}:/command-runner
+      - ${PIPE_OUTPUT_FILE}:/output.txt
 
   image_decryptor:
     image: frankhart2018/primistore:image-decryptor-v0.2

--- a/pi/execute_pipe.py
+++ b/pi/execute_pipe.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import subprocess
+
+
+PIPE_PATH = Path.home() / "command-runner"
+PIPE_OUTPUT_PATH = Path.home() / "output.txt"
+
+
+while True:
+    with open(PIPE_PATH) as f:
+        command = f.read().strip()
+
+    output = subprocess.getoutput(command)
+
+    with open(PIPE_OUTPUT_PATH, "w") as f:
+        f.write(output)

--- a/pi/primistore-startup.sh
+++ b/pi/primistore-startup.sh
@@ -27,6 +27,11 @@ fi
 
 IP=`python3 /usr/bin/get_current_ip.py`
 LOCAL_DIR=$HOME/.primistore
+PIPE_PATH=$HOME/command-runner
+PIPE_OUTPUT_PATH=$HOME/output.txt
 DOCKER_COMPOSE_PATH=$HOME/docker-compose-prod-pi.yml
+
+mkfifo $PIPE_PATH
+while true; do eval "$(cat test)" &> output.txt; done &
 
 sudo IP=$IP LOCAL_DIR=$LOCAL_DIR docker-compose -f $DOCKER_COMPOSE_PATH up -d

--- a/pi/primistore-startup.sh
+++ b/pi/primistore-startup.sh
@@ -33,5 +33,6 @@ DOCKER_COMPOSE_PATH=$HOME/docker-compose-prod-pi.yml
 
 mkfifo $PIPE_PATH
 python3 execute_pipe.py &
+touch $PIPE_OUTPUT_PATH
 
 sudo IP=$IP LOCAL_DIR=$LOCAL_DIR PIPE_PATH=$PIPE_PATH PIPE_OUTPUT_FILE=$PIPE_OUTPUT_PATH docker-compose -f $DOCKER_COMPOSE_PATH up -d

--- a/pi/primistore-startup.sh
+++ b/pi/primistore-startup.sh
@@ -32,6 +32,6 @@ PIPE_OUTPUT_PATH=$HOME/output.txt
 DOCKER_COMPOSE_PATH=$HOME/docker-compose-prod-pi.yml
 
 mkfifo $PIPE_PATH
-while true; do eval "$(cat test)" &> output.txt; done &
+python3 execute_pipe.py &
 
-sudo IP=$IP LOCAL_DIR=$LOCAL_DIR docker-compose -f $DOCKER_COMPOSE_PATH up -d
+sudo IP=$IP LOCAL_DIR=$LOCAL_DIR PIPE_PATH=$PIPE_PATH PIPE_OUTPUT_FILE=$PIPE_OUTPUT_PATH docker-compose -f $DOCKER_COMPOSE_PATH up -d


### PR DESCRIPTION
Closes #31 

**Implementation**

1. Add an API to fetch device info if on raspberry pi, otherwise return an object with all values set to "Cannot determine". 
2. This API needs access to raspberry pi from the node docker container (password-manager service), and thus makes use of a named pipe to do so (more details [here](https://stackoverflow.com/questions/32163955/how-to-run-shell-script-on-host-from-docker-container/63719458#63719458)). 
3. Update the API call to use this new API instead of using the CPU temp API to display all of these device information. 
4. To prevent calling the program to fetch new system info every time the page is visited, the API results are cached and are only updated (i.e. command is sent to pipe for execution) only after a certain threshold has been crossed since the last time the file was updated, otherwise the previous results are served from the file. 