### PR TITLE
Add basic protocol for talking to named pipes 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - ${LOCAL_DIR}:/root/.primistore
       - ${PIPE_PATH}:/command-runner
-      - ${PIPE_OUTPUT_FILE}:/output.txt
+      - ${PIPE_OUTPUT_DIR}:/pipe-outputs
 
   image_decryptor:
     build:

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -8,7 +8,7 @@ import {
 } from "fs";
 
 const PIPE_PATH = "/command-runner";
-const PIPE_OUTPUT_PATH = "/output.txt";
+const PIPE_OUTPUT_PATH = "/pipe-outputs/output.txt";
 const PIPE_OUTPUT_CACHE_MINUTES = 3;
 const PIPE_WAIT_SLEEP_TIME = 100; // milliseconds
 

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -1,14 +1,10 @@
 import { execSync } from "child_process";
-import {
-  createWriteStream,
-  existsSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "fs";
+import path from "path";
+import { existsSync, readFileSync, statSync, writeFileSync } from "fs";
 
 const PIPE_PATH = "/command-runner";
-const PIPE_OUTPUT_PATH = "/pipe-outputs/output.txt";
+const PIPE_OUTPUT_DIR = "/pipe-outputs";
+const PIPE_OUTPUT_PATH = path.join(PIPE_OUTPUT_DIR, "output.txt");
 const PIPE_OUTPUT_CACHE_MINUTES = 3;
 const PIPE_WAIT_SLEEP_TIME = 100; // milliseconds
 
@@ -22,6 +18,20 @@ class CommandOutput {
     this.type = type;
     this.value = value;
   }
+}
+
+class PipeCommand {
+  constructor(cmd, outputPath = PIPE_OUTPUT_PATH) {
+    this.cmd = cmd;
+    this.outputPath = outputPath;
+  }
+
+  serialize = () => {
+    return JSON.stringify({
+      cmd: this.cmd,
+      outputPath: this.outputPath,
+    });
+  };
 }
 
 const runCommand = (cmd) => {
@@ -58,6 +68,8 @@ const getCachedOutput = (filePath) => {
         CommandOutputType.Success,
         readFileSync(filePath).toString()
       );
+    } else {
+      lastModifiedCached = -1;
     }
   }
 
@@ -93,7 +105,7 @@ const runCommandInPipe = (
     );
   }
 
-  writeFileSync(PIPE_PATH, cmd);
+  writeFileSync(PIPE_PATH, cmd.serialize());
 
   // If output path does not exist, wait for it to be created
   // Edge case, will happen only first time
@@ -140,4 +152,6 @@ export {
   generateAESKeyIV,
   encryptWithAES,
   CommandOutputType,
+  PipeCommand,
+  PIPE_OUTPUT_DIR,
 };

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -80,13 +80,17 @@ const runCommandInPipe = (
   }
 
   let lastModified = -1;
-  if (withCache) {
+  if (withCache && outputPath !== PIPE_OUTPUT_PATH) {
     const { lastModifiedCached, outputCached } = getCachedOutput(outputPath);
     if (lastModifiedCached !== -1) {
       return outputCached;
     }
 
     lastModified = lastModifiedCached;
+  } else if (withCache && outputPath === PIPE_OUTPUT_PATH) {
+    throw new Error(
+      "If using cache, cannot use generic output path, as the contents are often overwritten!"
+    );
   }
 
   writeFileSync(PIPE_PATH, cmd);

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -86,12 +86,6 @@ const runCommandInPipe = (cmd) => {
     // Otherwise wait for the file to be modified
     while (true) {
       const lastModifiedUpdated = getFileLastModified(PIPE_OUTPUT_PATH);
-      if (lastModifiedUpdated == -2) {
-        return CommandOutput(
-          CommandOutputType.Error,
-          "Cannot read command output"
-        );
-      }
 
       if (lastModified !== lastModifiedUpdated) {
         break;

--- a/microservices/password-manager/utils/command-utils.js
+++ b/microservices/password-manager/utils/command-utils.js
@@ -59,12 +59,12 @@ const getCachedOutput = (filePath) => {
         readFileSync(filePath).toString()
       );
     }
-
-    return {
-      lastModifiedCached,
-      outputCached,
-    };
   }
+
+  return {
+    lastModifiedCached,
+    outputCached,
+  };
 };
 
 const runCommandInPipe = (

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -1,4 +1,10 @@
-import { CommandOutputType, runCommandInPipe } from "./command-utils.js";
+import path from "path";
+import {
+  CommandOutputType,
+  PIPE_OUTPUT_DIR,
+  PipeCommand,
+  runCommandInPipe,
+} from "./command-utils.js";
 
 const DEVICE_INFO_PIPE_OUTPUT_PATH = "/pipe-outputs/device-info-output.txt";
 
@@ -25,11 +31,15 @@ const convertStringToObject = (rawOutput, keyTransformer) => {
 
 const getDeviceInfo = () => {
   let output;
+  const command = new PipeCommand(
+    "/usr/bin/landscape-sysinfo",
+    "device-info-output.txt"
+  );
   try {
     output = runCommandInPipe(
-      "/usr/bin/landscape-sysinfo",
+      command,
       true,
-      DEVICE_INFO_PIPE_OUTPUT_PATH
+      path.join(PIPE_OUTPUT_DIR, command.outputPath)
     );
   } catch (e) {
     console.log(e);

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -1,6 +1,6 @@
 import { CommandOutputType, runCommandInPipe } from "./command-utils.js";
 
-const DEVICE_INFO_PIPE_OUTPUT_PATH = "./device-info-output.txt";
+const DEVICE_INFO_PIPE_OUTPUT_PATH = "/pipe-outputs/device-info-output.txt";
 
 const convertStringToObject = (rawOutput, keyTransformer) => {
   const systemInfo = {};

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -1,5 +1,7 @@
 import { CommandOutputType, runCommandInPipe } from "./command-utils.js";
 
+const DEVICE_INFO_PIPE_OUTPUT_PATH = "./device-info-output.txt";
+
 const convertStringToObject = (rawOutput, keyTransformer) => {
   const systemInfo = {};
   const lines = rawOutput.split("\n");
@@ -22,7 +24,11 @@ const convertStringToObject = (rawOutput, keyTransformer) => {
 };
 
 const getDeviceInfo = () => {
-  const output = runCommandInPipe("/usr/bin/landscape-sysinfo");
+  const output = runCommandInPipe(
+    "/usr/bin/landscape-sysinfo",
+    true,
+    DEVICE_INFO_PIPE_OUTPUT_PATH
+  );
 
   const keyTransformer = {
     "System load": "System load",

--- a/microservices/password-manager/utils/device-utils.js
+++ b/microservices/password-manager/utils/device-utils.js
@@ -24,11 +24,17 @@ const convertStringToObject = (rawOutput, keyTransformer) => {
 };
 
 const getDeviceInfo = () => {
-  const output = runCommandInPipe(
-    "/usr/bin/landscape-sysinfo",
-    true,
-    DEVICE_INFO_PIPE_OUTPUT_PATH
-  );
+  let output;
+  try {
+    output = runCommandInPipe(
+      "/usr/bin/landscape-sysinfo",
+      true,
+      DEVICE_INFO_PIPE_OUTPUT_PATH
+    );
+  } catch (e) {
+    console.log(e);
+    return {};
+  }
 
   const keyTransformer = {
     "System load": "System load",

--- a/pi/README.md
+++ b/pi/README.md
@@ -13,3 +13,5 @@ This directory contains all the things that are required to run PrimiStore on Ra
 4. `nptforce`: This has to be copied to `/usr/bin` and given execute permission (`chmod +x`), then running this command from anywhere in the Pi will force an NTP sync and fix the time.
 
 5. `execute_pipe.py`: Reads data from pipe and executes them as commands, dumps the output to an output file. This should be moved to the home directory.
+
+6. `backup.sh`: Pulls in mongodump from mongo docker container, and tarballs the charsets directory into a single tarball with the timestamp of the backup. This needs to be moved to the home directory.

--- a/pi/backup.sh
+++ b/pi/backup.sh
@@ -10,8 +10,8 @@ if [ "$MONGO_CONTAINER_COUNTS" -eq "1" ]; then
 
     cd ~/
     MONGO_CONTAINER_ID=$(sudo docker ps -q --filter "ancestor=mongo:bionic" | head -n 1)
-    sudo docker exec -it $MONGO_CONTAINER_ID mongodump --host localhost --db primistore
-    sudo docker cp $MONGO_CONTAINER_ID:/dump .
+    sudo docker exec -it $MONGO_CONTAINER_ID mongodump --host localhost --db primistore --quiet 
+    sudo docker cp $MONGO_CONTAINER_ID:/dump . > /dev/null 2>&1
     sudo tar czf mongodump.tar.gz dump
     sudo rm -rf dump
     sudo docker exec -it $MONGO_CONTAINER_ID rm -rf /dump
@@ -21,6 +21,7 @@ if [ "$MONGO_CONTAINER_COUNTS" -eq "1" ]; then
     sudo mv $PRIMISTORE_TARBALL_PATH $BACKUP_DIR
     sudo tar czf $BACKUP_TARBALL_PATH $BACKUP_DIR
     sudo rm -rf $BACKUP_DIR
+    echo $BACKUP_TARBALL_PATH
 else
     echo "More than one containers running MongoDB, please check your docker setup"
 fi

--- a/pi/backup.sh
+++ b/pi/backup.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+tarball() {
+    sudo tar czf $1 $2
+}
+
+docker_exec() {
+    sudo docker exec -it $1 $2
+}
+
 MONGO_CONTAINER_COUNTS=$(sudo docker ps -q --filter "ancestor=mongo:bionic" | wc -l)
 if [ "$MONGO_CONTAINER_COUNTS" -eq "1" ]; then
     CURRENT_TIME=$(date +%s)
@@ -10,16 +18,16 @@ if [ "$MONGO_CONTAINER_COUNTS" -eq "1" ]; then
 
     cd ~/
     MONGO_CONTAINER_ID=$(sudo docker ps -q --filter "ancestor=mongo:bionic" | head -n 1)
-    sudo docker exec -it $MONGO_CONTAINER_ID mongodump --host localhost --db primistore --quiet 
+    docker_exec $MONGO_CONTAINER_ID "mongodump --host localhost --db primistore --quiet"
     sudo docker cp $MONGO_CONTAINER_ID:/dump . > /dev/null 2>&1
-    sudo tar czf mongodump.tar.gz dump
+    tarball mongodump.tar.gz dump
     sudo rm -rf dump
-    sudo docker exec -it $MONGO_CONTAINER_ID rm -rf /dump
+    docker_exec $MONGO_CONTAINER_ID "rm -rf /dump"
     sudo mkdir $BACKUP_DIR
     sudo mv mongodump.tar.gz $BACKUP_DIR
-    sudo tar czf $PRIMISTORE_TARBALL_PATH $PRIMISTORE_DIR
+    tarball $PRIMISTORE_TARBALL_PATH $PRIMISTORE_DIR
     sudo mv $PRIMISTORE_TARBALL_PATH $BACKUP_DIR
-    sudo tar czf $BACKUP_TARBALL_PATH $BACKUP_DIR
+    tarball $BACKUP_TARBALL_PATH $BACKUP_DIR
     sudo rm -rf $BACKUP_DIR
     echo $BACKUP_TARBALL_PATH
 else

--- a/pi/docker-compose-prod-pi.yml
+++ b/pi/docker-compose-prod-pi.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - ${LOCAL_DIR}:/root/.primistore
       - ${PIPE_PATH}:/command-runner
-      - ${PIPE_OUTPUT_FILE}:/output.txt
+      - ${PIPE_OUTPUT_DIR}:/pipe-outputs
 
   image_decryptor:
     image: frankhart2018/primistore:image-decryptor-v0.3

--- a/pi/execute_pipe.py
+++ b/pi/execute_pipe.py
@@ -1,16 +1,23 @@
 from pathlib import Path
 import subprocess
+import json
 
 
 PIPE_PATH = Path.home() / "command-runner"
-PIPE_OUTPUT_PATH = Path.home() / "output.txt"
+PIPE_OUTPUT_DIR = Path.home() / "pipe-outputs"
 
 
 while True:
     with open(PIPE_PATH) as f:
         command = f.read().strip()
 
-    output = subprocess.getoutput(command)
+    try:
+        command_obj = json.loads(command)
+    except:
+        command_obj = {"cmd": "", "outputPath": "output.txt"}
 
-    with open(PIPE_OUTPUT_PATH, "w") as f:
+    output = subprocess.getoutput(command_obj["cmd"])
+    output_path = PIPE_OUTPUT_DIR / command_obj["outputPath"]
+
+    with open(output_path, "w") as f:
         f.write(output)


### PR DESCRIPTION
Closes #44 

**Implementation**

1. Make caching of output optional, and require them to pass a separate output file to dump data into, so that other (non-caching) command outputs do not overwrite it. 
2. Mount a directory of named pipe execution outputs instead of a single `output.txt`, by default all output will still go to `output.txt` unless overridden. Only commands that require caching will use their output files, all other commands will be dumped into the generic `output.txt`.
3. Instead of passing a raw string as command, wrap it in a PipeCommand object that holds the command and the path to output file, this is serialized into JSON and passed over to the command executor script which then deserializes the JSON, runs the command and puts it into required output file. 