### PR TITLE
Clear state on decrypt password page issue77

### DIFF
--- a/frontend/src/components/pages/DecryptPassword/DecryptPassword.js
+++ b/frontend/src/components/pages/DecryptPassword/DecryptPassword.js
@@ -73,8 +73,10 @@ const DecryptPassword = () => {
       navigator.clipboard.writeText(decryptedData);
       window.alert("Decrypted password copied to clipboard!");
     }
+    dispatch(decryptPasswordThunk({ passUid, pmsFile: null }));
     if (decryptedData.length === 0) return;
     setStats(computeDecryptedDataStats(decryptedData));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [decryptedData]);
 
   return (


### PR DESCRIPTION
### Clear state on decrypt password page  with reference to issue 77

To clear the previous decrypted data from state when the component mounts, you can add a cleanup function in the useEffect hook with an empty dependency array []. Here's how you can modify your useEffect hook:By dispatching decryptPasswordThunk({ passUid, pmsFile: null }), you're effectively clearing the decrypted data when the component mounts.