### PR TITLE
fixed the dockerfile at passwordmanager

### DIFF
--- a/microservices/password-manager/Dockerfile
+++ b/microservices/password-manager/Dockerfile
@@ -20,4 +20,4 @@ RUN apk --no-cache add openssl
 EXPOSE 4000
 
 # Command to run your application
-CMD ["node", "app.js"]
+CMD ["npm", "start"]


### PR DESCRIPTION
To compile and run typescript in password manager which was failing due to a bad build command in the dockerfile

#95 
#54 
 Changes to be committed:
	modified:   microservices/password-manager/Dockerfile