### PR TITLE
Backfill and choose initial policies

### DIFF
--- a/frontend/src/components/pages/CreatePassword/CreatePassword.tsx
+++ b/frontend/src/components/pages/CreatePassword/CreatePassword.tsx
@@ -11,14 +11,12 @@ const CreatePassword = () => {
   const dispatch = useDispatch<any>();
 
   const generatePassword = () => {
-    console.log(policies);
-    console.log("Policy:", policy);
-
-    // dispatch(
-    //   createPasswordThunk({
-    //     identifier,
-    //   })
-    // );
+    dispatch(
+      createPasswordThunk({
+        identifier,
+        policy,
+      })
+    );
   };
 
   useEffect(() => {

--- a/frontend/src/components/pages/CreatePassword/CreatePassword.tsx
+++ b/frontend/src/components/pages/CreatePassword/CreatePassword.tsx
@@ -1,20 +1,39 @@
-import React, { useState } from "react";
-import { useDispatch } from "react-redux";
-import { createPasswordThunk } from "../../../services/password-thunk";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { createPasswordThunk, fetchPoliciesThunk } from "../../../services/password-thunk";
 import NavBar from "../../parts/NavBar/NavBar";
 
 const CreatePassword = () => {
-  let [identifier, setIdentifier] = useState<string>("");
+  const { policies } = useSelector((state: any) => state.password);
+  const [identifier, setIdentifier] = useState<string>("");
+  const [policy, setPolicy] = useState<string>("");
 
   const dispatch = useDispatch<any>();
 
   const generatePassword = () => {
-    dispatch(
-      createPasswordThunk({
-        identifier,
-      }),
-    );
+    console.log(policies);
+    console.log("Policy:", policy);
+
+    // dispatch(
+    //   createPasswordThunk({
+    //     identifier,
+    //   })
+    // );
   };
+
+  useEffect(() => {
+    dispatch(fetchPoliciesThunk());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (policies !== null) {
+      if (policies.length === 0) {
+        alert("No policies found. Please create a policy first.");
+        window.location.href = "/policy";
+      }
+      setPolicy(policies[0]._id);
+    }
+  }, [policies]);
 
   return (
     <div>
@@ -36,6 +55,29 @@ const CreatePassword = () => {
               setIdentifier(e.target.value)
             }
           />
+        </div>
+        <div className="mb-10 w-5/6 space-y-5">
+          <label
+            htmlFor="policy"
+            className="block mb-2 text-md font-medium text-gray-900 capitalize"
+          >
+            Password Policy
+          </label>
+          <select
+            id="policy"
+            className="bg-transparent border border-gray-950 text-gray-900 text-md rounded-lg block w-full p-2.5"
+            value={policy}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              setPolicy(e.target.value)
+            }
+          >
+            {policies !== null &&
+              policies.map((policy: any) => (
+                <option key={policy._id} value={policy._id}>
+                  {policy.policy_name} (min: {policy.update_window_min}, max: {policy.update_window_max})
+                </option>
+              ))}
+          </select>
         </div>
         <button
           type="button"

--- a/frontend/src/components/pages/CreatePolicy/CreatePolicy.tsx
+++ b/frontend/src/components/pages/CreatePolicy/CreatePolicy.tsx
@@ -45,14 +45,14 @@ const CreatePolicy = () => {
       <div className="w-5/6 mx-auto py-7 flex flex-col justify-center items-center">
         <div className="mb-10 w-5/6 space-y-5">
           <label
-            htmlFor="identifier"
+            htmlFor="name"
             className="block mb-2 text-md font-medium text-gray-900 capitalize"
           >
             Policy Name (should be unique)
           </label>
           <input
             type="text"
-            id="identifier"
+            id="name"
             className="bg-transparent border border-gray-950 text-gray-900 text-md rounded-lg block w-full p-2.5"
             value={policyName}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -62,14 +62,14 @@ const CreatePolicy = () => {
         </div>
         <div className="mb-10 w-5/6 space-y-5">
           <label
-            htmlFor="identifier"
+            htmlFor="min"
             className="block mb-2 text-md font-medium text-gray-900 capitalize"
           >
             Update Window Min
           </label>
           <input
             type="number"
-            id="identifier"
+            id="min"
             min={0}
             className="bg-transparent border border-gray-950 text-gray-900 text-md rounded-lg block w-full p-2.5"
             value={updateWindowMin}
@@ -80,14 +80,14 @@ const CreatePolicy = () => {
         </div>
         <div className="mb-10 w-5/6 space-y-5">
           <label
-            htmlFor="identifier"
+            htmlFor="max"
             className="block mb-2 text-md font-medium text-gray-900 capitalize"
           >
             Update Window Max
           </label>
           <input
             type="number"
-            id="identifier"
+            id="max"
             min={0}
             className="bg-transparent border border-gray-950 text-gray-900 text-md rounded-lg block w-full p-2.5"
             value={updateWindowMax}

--- a/frontend/src/models/passwordInterface.ts
+++ b/frontend/src/models/passwordInterface.ts
@@ -44,6 +44,13 @@ interface DeviceInfo {
   [key: string]: any;
 }
 
+interface Policy {
+  _id: string;
+  policy_name: string;
+  update_window_min: number;
+  update_window_max: number;
+}
+
 interface InitialState {
   created: boolean;
   passwords: Password[];
@@ -54,6 +61,7 @@ interface InitialState {
   backupName: string | null;
   backupData: any | null;
   backupRestorationSuccess: boolean;
+  policies: Policy[] | null;
 }
 
 export {

--- a/frontend/src/models/passwordInterface.ts
+++ b/frontend/src/models/passwordInterface.ts
@@ -1,5 +1,6 @@
 interface PasswordPayload {
   identifier: string;
+  policy: string;
 }
 interface RotateAESKeyAndIVPayload {
   passUid: string;

--- a/frontend/src/reducers/password-reducer.ts
+++ b/frontend/src/reducers/password-reducer.ts
@@ -12,6 +12,7 @@ import {
   downloadBackupThunk,
   uploadBackupThunk,
   createPolicyThunk,
+  fetchPoliciesThunk,
 } from "../services/password-thunk";
 import { InitialState } from "../models/passwordInterface";
 import { COLS, ROWS } from "../utils/constants";
@@ -35,6 +36,7 @@ const initialState: InitialState = {
   backupName: null,
   backupData: null,
   backupRestorationSuccess: false,
+  policies: null,
 };
 
 const passwordSlice = createSlice({
@@ -186,6 +188,16 @@ const passwordSlice = createSlice({
 
       if ("data" in payload) {
         alert("Policy created successfully");
+      } else {
+        alert(payload.response.data.error);
+      }
+    });
+
+    builder.addCase(fetchPoliciesThunk.fulfilled, (state, action: any) => {
+      const payload = action.payload;
+
+      if ("data" in payload) {
+        state.policies = payload.data;
       } else {
         alert(payload.response.data.error);
       }

--- a/frontend/src/services/password-service.ts
+++ b/frontend/src/services/password-service.ts
@@ -5,9 +5,10 @@ import {
   PASSWORD_MANAGER_API_BASE,
 } from "../utils/constants";
 
-export const createPassword = async (passwordUid: string) => {
+export const createPassword = async (passwordUid: string, policy_id: string) => {
   const response = await axios.post(`${PASSWORD_MANAGER_API_BASE}/password`, {
     identifier: passwordUid,
+    policy_id,
   });
 
   return response;

--- a/frontend/src/services/password-service.ts
+++ b/frontend/src/services/password-service.ts
@@ -124,3 +124,8 @@ export const createPolicy = async (
 
   return response;
 };
+
+export const fetchPolicies = async () => {
+  const response = await axios.get(`${PASSWORD_MANAGER_API_BASE}/policy`);
+  return response;
+};

--- a/frontend/src/services/password-thunk.ts
+++ b/frontend/src/services/password-thunk.ts
@@ -17,7 +17,7 @@ export const createPasswordThunk = createAsyncThunk(
   "password/createPassword",
   async (payload: PasswordPayload) => {
     try {
-      const response = await passwordService.createPassword(payload.identifier);
+      const response = await passwordService.createPassword(payload.identifier, payload.policy);
       return response;
     } catch (e) {
       return e;

--- a/frontend/src/services/password-thunk.ts
+++ b/frontend/src/services/password-thunk.ts
@@ -161,3 +161,15 @@ export const createPolicyThunk = createAsyncThunk(
     }
   },
 );
+
+export const fetchPoliciesThunk = createAsyncThunk(
+  "password/fetchPolicies",
+  async () => {
+    try {
+      const response = await passwordService.fetchPolicies();
+      return response;
+    } catch (e) {
+      return e;
+    }
+  },
+);

--- a/microservices/password-manager/controllers/primistore/password-schema.ts
+++ b/microservices/password-manager/controllers/primistore/password-schema.ts
@@ -6,6 +6,7 @@ interface IPassword {
   aes_last_rotated: string;
   pass_uid: string;
   charset_last_rotated: string;
+  policy_id: string;
 }
 
 const schema = new mongoose.Schema<IPassword>(
@@ -15,6 +16,7 @@ const schema = new mongoose.Schema<IPassword>(
     aes_last_rotated: String,
     pass_uid: String,
     charset_last_rotated: String,
+    policy_id: String,
   },
   {
     collection: "passwords",

--- a/microservices/password-manager/controllers/primistore/primistore-controller.ts
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.ts
@@ -13,6 +13,7 @@ import {
   createPolicy,
   getPasswordByPassUid,
   getPasswords,
+  getPolicies,
   removePasswordByPassUid,
   updatePasswordAES,
   updatePasswordCharset,
@@ -365,6 +366,16 @@ const createPolicyHandler = async (
   });
 };
 
+const getAllPoliciesHandler = async (
+  req: Request,
+  res: Response,
+  logger: Logger,
+) => {
+  const policies = await getPolicies();
+  logger.info(`[${getCurrentTime()}] GET /policy : Status 200`);
+  return res.status(200).send(policies);
+};
+
 const PrimistoreController = (app: Application, logger: Logger) => {
   //////////////////////////////////////////
   // Password Endpoints
@@ -406,6 +417,7 @@ const PrimistoreController = (app: Application, logger: Logger) => {
   // Policy Endpoints
   //////////////////////////////////////////
   app.post("/policy", (req, res) => createPolicyHandler(req, res, logger));
+  app.get("/policy", (req, res) => getAllPoliciesHandler(req, res, logger));
 };
 
 export default PrimistoreController;

--- a/microservices/password-manager/controllers/primistore/primistore-controller.ts
+++ b/microservices/password-manager/controllers/primistore/primistore-controller.ts
@@ -56,7 +56,7 @@ const passwordCreationHandler = async (
   res: Response,
   logger: Logger,
 ) => {
-  const password_uid = req.body.identifier;
+  const {identifier, policy_id} = req.body;
 
   const { key, iv } = generateAESKeyIV();
   if (
@@ -73,10 +73,10 @@ const passwordCreationHandler = async (
   }
 
   const charset = generateCharset();
-  const charset_path = path.join(PRIMISTORE_DIR, `charset-${password_uid}.txt`);
+  const charset_path = path.join(PRIMISTORE_DIR, `charset-${identifier}.txt`);
   fs.writeFileSync(charset_path, charset);
 
-  await createPassword(password_uid, key.value, iv.value);
+  await createPassword(identifier, key.value, iv.value, policy_id);
 
   logger.info(`[${getCurrentTime()}] POST /password : Status 200`);
   res.status(200).send({

--- a/microservices/password-manager/controllers/primistore/primistore-dao.ts
+++ b/microservices/password-manager/controllers/primistore/primistore-dao.ts
@@ -6,6 +6,7 @@ export const createPassword = (
   pass_uid: string,
   aes_key: string,
   aes_iv: string,
+  policy_id: string,
 ): Promise<IPassword | any> => {
   let currentTime = Math.floor(Date.now() / 1000).toString();
 
@@ -17,6 +18,7 @@ export const createPassword = (
       aes_iv,
       aes_last_rotated: currentTime,
       charset_last_rotated: currentTime,
+      policy_id,
     },
   };
 

--- a/microservices/password-manager/controllers/primistore/primistore-dao.ts
+++ b/microservices/password-manager/controllers/primistore/primistore-dao.ts
@@ -93,3 +93,7 @@ export const createPolicy = (
   const options = { upsert: true, new: true };
   return policyModel.findOneAndUpdate(query, update, options);
 };
+
+export const getPolicies = (): Promise<IPolicy[]> => {
+  return policyModel.find();
+}


### PR DESCRIPTION
Closes #60 

**Implementation**

1. Add a new endpoint to return all policies.
2. Load the policies while creating password, if there are none then redirect to create policy page. 
3. Update `POST /password` to also store the policy id of the policy that is to be used with the password. 
4. Post the loaded policy id from the frontend during password creation. 