### PR TITLE
Add pm2 to startup script

### DIFF
--- a/pi/primistore-startup.sh
+++ b/pi/primistore-startup.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 
 # A bash script to be run on Raspberry Pi startup to spin
-# up the apps
+# up the app
 
-check_command_installed() {
-    OUTPUT=$(which $1)
+check_command_installed_custom_message() {
+	OUTPUT=$(which $1)
 	if [ -z "$OUTPUT" ]; then
-		echo "Please install $2, use 'sudo apt install $2 -y'"
+		echo $2
         return 1
 	fi
 
     return 0
+}
+
+check_command_installed() {
+	check_command_installed_custom_message $1 "Please install $2, use 'sudo apt install $2 -y'"
+	return $?
 }
 
 make_fifo_if_not_exists() {
@@ -20,12 +25,17 @@ make_fifo_if_not_exists() {
 }
 
 TOTAL=0
+
 check_command_installed "ifconfig" "net-tools"
 TOTAL=$((TOTAL + $?))
 check_command_installed "docker" "docker.io"
 TOTAL=$((TOTAL + $?))
 check_command_installed "docker-compose" "docker-compose"
 TOTAL=$((TOTAL + $?))
+
+check_command_installed_custom_message "pm2" "Please install pm2, follow: 'https://pm2.io/docs/runtime/guide/installation/'"
+TOTAL=$((TOTAL + $?))
+
 if [ $TOTAL -gt 0 ]; then
 	echo "Some errors exist"
 	return 1
@@ -39,6 +49,6 @@ DOCKER_COMPOSE_PATH=$HOME/docker-compose-prod-pi.yml
 
 make_fifo_if_not_exists $PIPE_PATH
 mkdir -p $PIPE_COMM_DIR
-python3 execute_pipe.py &
+pm2 start --name pipe-executor "python3 execute_pipe.py"
 
 sudo IP=$IP LOCAL_DIR=$LOCAL_DIR PIPE_PATH=$PIPE_PATH PIPE_COMM_DIR=$PIPE_COMM_DIR docker-compose -f $DOCKER_COMPOSE_PATH up -d


### PR DESCRIPTION
Closes #91 

**Implementation**

1. Add checks for pm2 in startup script.
2. Replace running python script as a vanilla background process with pm2.  