### PR TITLE
Add edit password page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import GeneratePassword from "./components/pages/GeneratePassword/GeneratePasswo
 import VERSION from "./utils/version";
 import DeviceInfo from "./components/pages/DeviceInfo/DeviceInfo";
 import CreatePolicy from "./components/pages/CreatePolicy/CreatePolicy";
+import EditPassword from "./components/pages/EditPassword/EditPassword";
 
 const store = configureStore({
   reducer: {
@@ -45,6 +46,7 @@ const App = () => {
           <Route path="/generate-password" element={<GeneratePassword />} />
           <Route path="/device-info" element={<DeviceInfo />} />
           <Route path="/policy" element={<CreatePolicy />} />
+          <Route path="/password/edit/:pass_uid" element={<EditPassword />} />
         </Routes>
       </Provider>
     </div>

--- a/frontend/src/components/pages/CreatePassword/CreatePassword.tsx
+++ b/frontend/src/components/pages/CreatePassword/CreatePassword.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { createPasswordThunk, fetchPoliciesThunk } from "../../../services/password-thunk";
+import {
+  createPasswordThunk,
+  fetchPoliciesThunk,
+} from "../../../services/password-thunk";
 import NavBar from "../../parts/NavBar/NavBar";
 
 const CreatePassword = () => {
@@ -15,7 +18,7 @@ const CreatePassword = () => {
       createPasswordThunk({
         identifier,
         policy,
-      })
+      }),
     );
   };
 
@@ -72,7 +75,8 @@ const CreatePassword = () => {
             {policies !== null &&
               policies.map((policy: any) => (
                 <option key={policy._id} value={policy._id}>
-                  {policy.policy_name} (min: {policy.update_window_min}, max: {policy.update_window_max})
+                  {policy.policy_name} (min: {policy.update_window_min}, max:{" "}
+                  {policy.update_window_max})
                 </option>
               ))}
           </select>

--- a/frontend/src/components/pages/EditPassword/EditPassword.tsx
+++ b/frontend/src/components/pages/EditPassword/EditPassword.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from "react";
+import NavBar from "../../parts/NavBar/NavBar";
+import { useDispatch } from "react-redux";
+import {
+  deletePasswordThunk,
+  fetchPoliciesThunk,
+  getPasswordPolicyIdThunk,
+  rotateAESKeyAndIVThunk,
+  rotateCharsetThunk,
+  updatePasswordPolicyThunk,
+} from "../../../services/password-thunk";
+import { useSelector } from "react-redux";
+
+const EditPassword = () => {
+  const { policies, currentPolicy } = useSelector(
+    (state: any) => state.password,
+  );
+  const [policy, setPolicy] = useState<string>("");
+
+  const pathName = window.location.pathname;
+  const passUid = pathName.split("/")[3];
+
+  const dispatch = useDispatch<any>();
+
+  const deletePassword = () => {
+    const userConfirmed = window.confirm(`Deleting password for ${passUid}`);
+
+    if (userConfirmed === true) {
+      dispatch(
+        deletePasswordThunk({
+          passUid,
+        }),
+      ).then(() => {
+        window.location.href = "/";
+      });
+    } else {
+      alert(`Retaining password for ${passUid}`);
+    }
+  };
+
+  const rotateAESKeyAndIV = () => {
+    const userConfirmed = window.confirm(
+      "Have you copied your current password?",
+    );
+
+    if (userConfirmed) {
+      dispatch(
+        rotateAESKeyAndIVThunk({
+          passUid,
+        }),
+      );
+    } else {
+      alert("Cancelling AES Key and IV rotation!");
+    }
+  };
+
+  const rotateCharset = () => {
+    const userConfirmed = window.confirm(
+      "Have you copied your current password?",
+    );
+
+    if (userConfirmed === true) {
+      dispatch(
+        rotateCharsetThunk({
+          passUid,
+        }),
+      );
+    } else {
+      alert("Cancelling Charset rotation!");
+    }
+  };
+
+  const updatePasswordPolicy = () => {
+    dispatch(
+      updatePasswordPolicyThunk({
+        passUid,
+        policyId: policy,
+      }),
+    ).then(() => {
+      window.location.reload();
+    });
+  };
+
+  useEffect(() => {
+    dispatch(fetchPoliciesThunk()).then(() => {
+      dispatch(getPasswordPolicyIdThunk({ passUid })).then(() => {
+        setPolicy(currentPolicy);
+      });
+    });
+  }, [dispatch, passUid, currentPolicy]);
+
+  return (
+    <div>
+      <NavBar />
+
+      <div className="w-5/6 mx-auto flex flex-col justify-center items-center">
+        <h1 className="text-2xl font-bold mt-5">Edit Password</h1>
+        <button
+          className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+          onClick={() => deletePassword()}
+        >
+          Delete Password
+        </button>
+        <button
+          onClick={() => rotateAESKeyAndIV()}
+          className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+        >
+          Rotate AES Key and IV
+        </button>
+        <button
+          onClick={() => rotateCharset()}
+          className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+        >
+          Rotate Charset
+        </button>
+
+        <div className="mb-10 w-5/6 space-y-5">
+          <label
+            htmlFor="policy"
+            className="block mb-2 text-md font-medium text-gray-900 capitalize"
+          >
+            Current Password Policy
+          </label>
+          <select
+            id="policy"
+            className="bg-transparent border border-gray-950 text-gray-900 text-md rounded-lg block w-full p-2.5"
+            value={policy}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              setPolicy(e.target.value)
+            }
+          >
+            {policies !== null &&
+              policies.map((policy: any) => (
+                <option key={policy._id} value={policy._id}>
+                  {policy.policy_name} (min: {policy.update_window_min}, max:{" "}
+                  {policy.update_window_max})
+                </option>
+              ))}
+          </select>
+          <button
+            onClick={() => updatePasswordPolicy()}
+            className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+          >
+            Update Password Policy
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EditPassword;

--- a/frontend/src/components/pages/ListPasswords/ListPasswords.tsx
+++ b/frontend/src/components/pages/ListPasswords/ListPasswords.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
-  deletePasswordThunk,
   fetchPasswordsThunk,
   fetchPolicyByIdThunk,
-  rotateAESKeyAndIVThunk,
-  rotateCharsetThunk,
 } from "../../../services/password-thunk";
 
 import "./ListPasswords.css";
@@ -23,50 +20,18 @@ const ListPasswords = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const rotateAESKeyAndIV = (passUid: string) => {
-    const userConfirmed = window.confirm(
-      "Have you copied your current password?"
-    );
-
-    if (userConfirmed) {
-      dispatch(
-        rotateAESKeyAndIVThunk({
-          passUid,
-        })
-      );
-    } else {
-      alert("Cancelling AES Key and IV rotation!");
-    }
-  };
-
-  const rotateCharset = (passUid: string) => {
-    const userConfirmed = window.confirm(
-      "Have you copied your current password?"
-    );
-
-    if (userConfirmed === true) {
-      dispatch(
-        rotateCharsetThunk({
-          passUid,
-        })
-      );
-    } else {
-      alert("Cancelling Charset rotation!");
-    }
-  };
-
   const dateDiffInDays = (date1: Date, date2: Date) => {
     const oneDayMs = 24 * 60 * 60 * 1000;
 
     const utcDate1 = Date.UTC(
       date1.getFullYear(),
       date1.getMonth(),
-      date1.getDate()
+      date1.getDate(),
     );
     const utcDate2 = Date.UTC(
       date2.getFullYear(),
       date2.getMonth(),
-      date2.getDate()
+      date2.getDate(),
     );
 
     const timeDiff = Math.abs(utcDate2 - utcDate1);
@@ -86,24 +51,13 @@ const ListPasswords = () => {
 
     if (days > policy.update_window_max) {
       return "red text-center";
-    } else if (days > policy.update_window_min && days <= policy.update_window_max) {
+    } else if (
+      days > policy.update_window_min &&
+      days <= policy.update_window_max
+    ) {
       return "yellow text-center";
     } else {
       return "green text-center";
-    }
-  };
-
-  const deletePassword = (passUid: string) => {
-    const userConfirmed = window.confirm(`Deleting password for ${passUid}`);
-
-    if (userConfirmed === true) {
-      dispatch(
-        deletePasswordThunk({
-          passUid,
-        })
-      );
-    } else {
-      alert(`Retaining password for ${passUid}`);
     }
   };
 
@@ -113,7 +67,7 @@ const ListPasswords = () => {
         dispatch(
           fetchPolicyByIdThunk({
             policyId: password_obj.policy_id,
-          })
+          }),
         );
       });
     }
@@ -148,80 +102,72 @@ const ListPasswords = () => {
             </tr>
           </thead>
           <tbody>
-            {(Object.keys(policy_map).length > 0 && passwords.length > 0) && passwords.map((password_obj: any, idx: number) => {
-              return (
-                <tr key={idx}>
-                  <td className="text-center font-bold">{idx + 1}</td>
-                  <td className="pl-5">{password_obj.pass_uid}</td>
-                  <td
-                    className={getClassByDays(
-                      daysSinceLastRotated(password_obj.aes_last_rotated),
-                      password_obj.policy_id
-                    )}
-                  >
-                    <button
-                      onClick={() => rotateAESKeyAndIV(password_obj.pass_uid)}
-                      className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+            {Object.keys(policy_map).length > 0 &&
+              passwords.length > 0 &&
+              passwords.map((password_obj: any, idx: number) => {
+                return (
+                  <tr key={idx}>
+                    <td className="text-center font-bold">{idx + 1}</td>
+                    <td className="pl-5">{password_obj.pass_uid}</td>
+                    <td
+                      className={getClassByDays(
+                        daysSinceLastRotated(password_obj.aes_last_rotated),
+                        password_obj.policy_id,
+                      )}
                     >
-                      Rotate AES Key and IV
-                    </button>
-                    <p className="mb-2">
-                      <span>
-                        <strong>Last rotated:</strong>{" "}
-                        {daysSinceLastRotated(password_obj.aes_last_rotated)}
-                      </span>{" "}
-                      day(s) ago
-                    </p>
-                  </td>
-                  <td
-                    className={getClassByDays(
-                      daysSinceLastRotated(password_obj.charset_last_rotated),
-                      password_obj.policy_id
-                    )}
-                  >
-                    <button
-                      onClick={() => rotateCharset(password_obj.pass_uid)}
-                      className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
-                    >
-                      Rotate Charset
-                    </button>
-                    <p className="mb-2">
-                      <span>
-                        <strong>Last rotated:</strong>{" "}
-                        {daysSinceLastRotated(
-                          password_obj.charset_last_rotated
-                        )}{" "}
+                      <p className="mb-2">
+                        <span>
+                          <strong>Last rotated:</strong>{" "}
+                          {daysSinceLastRotated(password_obj.aes_last_rotated)}
+                        </span>{" "}
                         day(s) ago
-                      </span>
-                    </p>
-                  </td>
-                  <td className="text-center">
-                    <NavLink
-                      className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
-                      to={{
-                        pathname: `/password/encrypt/${password_obj.pass_uid}`,
-                      }}
+                      </p>
+                    </td>
+                    <td
+                      className={getClassByDays(
+                        daysSinceLastRotated(password_obj.charset_last_rotated),
+                        password_obj.policy_id,
+                      )}
                     >
-                      Encrypt
-                    </NavLink>
-                    <NavLink
-                      className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
-                      to={{
-                        pathname: `/password/decrypt/${password_obj.pass_uid}`,
-                      }}
-                    >
-                      Decrypt
-                    </NavLink>
-                    <button
-                      className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
-                      onClick={() => deletePassword(password_obj.pass_uid)}
-                    >
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              );
-            })}
+                      <p className="mb-2">
+                        <span>
+                          <strong>Last rotated:</strong>{" "}
+                          {daysSinceLastRotated(
+                            password_obj.charset_last_rotated,
+                          )}{" "}
+                          day(s) ago
+                        </span>
+                      </p>
+                    </td>
+                    <td className="text-center">
+                      <NavLink
+                        className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+                        to={{
+                          pathname: `/password/encrypt/${password_obj.pass_uid}`,
+                        }}
+                      >
+                        Encrypt
+                      </NavLink>
+                      <NavLink
+                        className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+                        to={{
+                          pathname: `/password/decrypt/${password_obj.pass_uid}`,
+                        }}
+                      >
+                        Decrypt
+                      </NavLink>
+                      <button
+                        className="border bg-gray-400/60 border-gray-600 hover:bg-gray-900 hover:text-white focus:outline-none focus:ring-4 focus:ring-gray-300 font-medium rounded-full w-fit text-base px-3 py-2.5 me-2 my-2"
+                        onClick={() => {
+                          window.location.href = `/password/edit/${password_obj.pass_uid}`;
+                        }}
+                      >
+                        Edit Password
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
           </tbody>
         </table>
       </div>

--- a/frontend/src/models/passwordInterface.ts
+++ b/frontend/src/models/passwordInterface.ts
@@ -37,6 +37,13 @@ interface CreatePolicyThunk {
 interface FetchPolicyByIdThunk {
   policyId: string;
 }
+interface PasswordPolicyIdThunk {
+  passUid: string;
+}
+interface PasswordPolicyUpdateThunk {
+  passUid: string;
+  policyId: string;
+}
 
 interface Password {
   pass_uid: string;
@@ -72,6 +79,7 @@ interface InitialState {
   backupRestorationSuccess: boolean;
   policies: Policy[] | null;
   policy_map: PolicyMap;
+  currentPolicy: Policy | null;
 }
 
 export {
@@ -88,4 +96,6 @@ export {
   CreatePolicyThunk,
   FetchPolicyByIdThunk,
   Password,
+  PasswordPolicyIdThunk,
+  PasswordPolicyUpdateThunk,
 };

--- a/frontend/src/reducers/password-reducer.ts
+++ b/frontend/src/reducers/password-reducer.ts
@@ -14,6 +14,7 @@ import {
   createPolicyThunk,
   fetchPoliciesThunk,
   fetchPolicyByIdThunk,
+  getPasswordPolicyIdThunk,
 } from "../services/password-thunk";
 import { InitialState } from "../models/passwordInterface";
 import { COLS, ROWS } from "../utils/constants";
@@ -39,6 +40,7 @@ const initialState: InitialState = {
   backupRestorationSuccess: false,
   policies: null,
   policy_map: {},
+  currentPolicy: null,
 };
 
 const passwordSlice = createSlice({
@@ -215,6 +217,19 @@ const passwordSlice = createSlice({
         alert(payload.response.data.error);
       }
     });
+
+    builder.addCase(
+      getPasswordPolicyIdThunk.fulfilled,
+      (state, action: any) => {
+        const payload = action.payload;
+
+        if ("data" in payload) {
+          state.currentPolicy = payload.data.policy_id;
+        } else {
+          alert(payload.response.data.error);
+        }
+      },
+    );
   },
 });
 export const { clearEncryptedData, clearBackupInfo } = passwordSlice.actions;

--- a/frontend/src/services/password-service.ts
+++ b/frontend/src/services/password-service.ts
@@ -5,7 +5,10 @@ import {
   PASSWORD_MANAGER_API_BASE,
 } from "../utils/constants";
 
-export const createPassword = async (passwordUid: string, policy_id: string) => {
+export const createPassword = async (
+  passwordUid: string,
+  policy_id: string,
+) => {
   const response = await axios.post(`${PASSWORD_MANAGER_API_BASE}/password`, {
     identifier: passwordUid,
     policy_id,
@@ -136,4 +139,25 @@ export const fetchPolicyById = async (policyId: string) => {
     `${PASSWORD_MANAGER_API_BASE}/policy/${policyId}`,
   );
   return response;
-}
+};
+
+export const getPasswordPolicyId = async (passUid: string) => {
+  const response = await axios.get(
+    `${PASSWORD_MANAGER_API_BASE}/password/policy/${passUid}`,
+  );
+  return response;
+};
+
+export const updatePasswordPolicy = async (
+  passUid: string,
+  policy_id: string,
+) => {
+  const response = await axios.put(
+    `${PASSWORD_MANAGER_API_BASE}/password/policy/${passUid}`,
+    {
+      policy_id,
+    },
+  );
+
+  return response;
+};

--- a/frontend/src/services/password-thunk.ts
+++ b/frontend/src/services/password-thunk.ts
@@ -11,6 +11,8 @@ import {
   UploadBackupThunk,
   CreatePolicyThunk,
   FetchPolicyByIdThunk,
+  PasswordPolicyIdThunk,
+  PasswordPolicyUpdateThunk,
 } from "../models/passwordInterface";
 import * as passwordService from "./password-service";
 
@@ -20,13 +22,13 @@ export const createPasswordThunk = createAsyncThunk(
     try {
       const response = await passwordService.createPassword(
         payload.identifier,
-        payload.policy
+        payload.policy,
       );
       return response;
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const fetchPasswordsThunk = createAsyncThunk(
@@ -34,7 +36,7 @@ export const fetchPasswordsThunk = createAsyncThunk(
   async () => {
     const response = await passwordService.fetchPasswords();
     return response;
-  }
+  },
 );
 
 export const rotateAESKeyAndIVThunk = createAsyncThunk(
@@ -46,7 +48,7 @@ export const rotateAESKeyAndIVThunk = createAsyncThunk(
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const rotateCharsetThunk = createAsyncThunk(
@@ -54,7 +56,7 @@ export const rotateCharsetThunk = createAsyncThunk(
   async (payload: RotateCharsetThunk) => {
     const response = await passwordService.rotateCharset(payload.passUid);
     return response;
-  }
+  },
 );
 
 export const encryptPasswordThunk = createAsyncThunk(
@@ -63,13 +65,13 @@ export const encryptPasswordThunk = createAsyncThunk(
     try {
       const response = await passwordService.encryptPassword(
         payload.passUid,
-        payload.password
+        payload.password,
       );
       return response;
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const decryptPasswordThunk = createAsyncThunk(
@@ -78,13 +80,13 @@ export const decryptPasswordThunk = createAsyncThunk(
     try {
       const response = await passwordService.decryptPassword(
         payload.passUid,
-        payload.pmsFile
+        payload.pmsFile,
       );
       return response;
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const deletePasswordThunk = createAsyncThunk(
@@ -96,7 +98,7 @@ export const deletePasswordThunk = createAsyncThunk(
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const getDeviceInfoThunk = createAsyncThunk(
@@ -108,7 +110,7 @@ export const getDeviceInfoThunk = createAsyncThunk(
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const generateBackupThunk = createAsyncThunk(
@@ -120,7 +122,7 @@ export const generateBackupThunk = createAsyncThunk(
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const downloadBackupThunk = createAsyncThunk(
@@ -132,7 +134,7 @@ export const downloadBackupThunk = createAsyncThunk(
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const uploadBackupThunk = createAsyncThunk(
@@ -141,13 +143,13 @@ export const uploadBackupThunk = createAsyncThunk(
     try {
       const response = await passwordService.uploadBackup(
         payload.backupFile,
-        payload.password
+        payload.password,
       );
       return response;
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const createPolicyThunk = createAsyncThunk(
@@ -157,13 +159,13 @@ export const createPolicyThunk = createAsyncThunk(
       const response = await passwordService.createPolicy(
         payload.policyName,
         payload.updateWindowMin,
-        payload.updateWindowMax
+        payload.updateWindowMax,
       );
       return response;
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const fetchPoliciesThunk = createAsyncThunk(
@@ -175,7 +177,7 @@ export const fetchPoliciesThunk = createAsyncThunk(
     } catch (e) {
       return e;
     }
-  }
+  },
 );
 
 export const fetchPolicyByIdThunk = createAsyncThunk(
@@ -187,5 +189,34 @@ export const fetchPolicyByIdThunk = createAsyncThunk(
     } catch (e) {
       return e;
     }
-  }
+  },
+);
+
+export const getPasswordPolicyIdThunk = createAsyncThunk(
+  "password/getPasswordPolicyId",
+  async (payload: PasswordPolicyIdThunk) => {
+    try {
+      const response = await passwordService.getPasswordPolicyId(
+        payload.passUid,
+      );
+      return response;
+    } catch (e) {
+      return e;
+    }
+  },
+);
+
+export const updatePasswordPolicyThunk = createAsyncThunk(
+  "password/updatePasswordPolicy",
+  async (payload: PasswordPolicyUpdateThunk) => {
+    try {
+      const response = await passwordService.updatePasswordPolicy(
+        payload.passUid,
+        payload.policyId,
+      );
+      return response;
+    } catch (e) {
+      return e;
+    }
+  },
 );

--- a/microservices/password-manager/controllers/primistore/primistore-dao.ts
+++ b/microservices/password-manager/controllers/primistore/primistore-dao.ts
@@ -66,6 +66,22 @@ export const updatePasswordCharset = (
   return passwordModel.findOneAndUpdate(query, update, options);
 };
 
+export const updatePasswordPolicy = (
+  pass_uid: string,
+  policy_id: string,
+): Promise<IPassword | null> => {
+  const query = { pass_uid };
+  const options = { new: true };
+
+  const update = {
+    $set: {
+      policy_id: policy_id,
+    },
+  };
+
+  return passwordModel.findOneAndUpdate(query, update, options);
+};
+
 export const getPasswordByPassUid = (
   pass_uid: string,
 ): Promise<IPassword | null> => {
@@ -98,8 +114,8 @@ export const createPolicy = (
 
 export const getPolicies = (): Promise<IPolicy[]> => {
   return policyModel.find();
-}
+};
 
 export const getPolicyById = (policy_id: string): Promise<IPolicy | null> => {
   return policyModel.findOne({ _id: policy_id });
-}
+};


### PR DESCRIPTION
Closes #61 

**Implementation**

1. Add a new edit password page.
2. Move delete password, rotate AES, rotate charset to this new page.
3. Add endpoint to fetch current policy for a password - `GET /password/policy/:passUid`.
4. Add endpoint to edit current policy for a password - `PUT /password/policy/:passUid`.
5. Add mechanism to load current password policy in edit password page.
6. Hookup endpoint to update password policy in edit password page.